### PR TITLE
Fix TTW save game parsing

### DIFF
--- a/src/falloutttwsavegame.cpp
+++ b/src/falloutttwsavegame.cpp
@@ -18,6 +18,7 @@ FalloutTTWSaveGame::FalloutTTWSaveGame(QString const &fileName, MOBase::IPluginG
   }
 
   file.setHasFieldMarkers(true);
+  file.setPluginString(GamebryoSaveGame::StringType::TYPE_BZSTRING);
 
   unsigned long width;
   file.read(width);
@@ -46,5 +47,6 @@ FalloutTTWSaveGame::FalloutTTWSaveGame(QString const &fileName, MOBase::IPluginG
   file.skip<char>(5); // unknown byte, size of plugin data
 
   //Abstract this
+  file.setPluginString(GamebryoSaveGame::StringType::TYPE_BSTRING);
   file.readPlugins();
 }

--- a/src/gameFalloutTTW.pro
+++ b/src/gameFalloutTTW.pro
@@ -14,14 +14,14 @@ CONFIG += dll
 DEFINES += GAMEFALLOUTTTW_LIBRARY
 
 SOURCES += gamefalloutTTW.cpp \
-    falloutttwbsaittwalidation.cpp \
+    falloutttwbsainvalidation.cpp \
     falloutttwscriptextender.cpp \
     falloutttwdataarchives.cpp \
     falloutttwsavegame.cpp \
     falloutttwsavegameinfo.cpp
 
 HEADERS += gamefalloutttw.h \
-    falloutttwbsaittwalidation.h \
+    falloutttwbsainvalidation.h \
     falloutttwscriptextender.h \
     falloutttwdataarchives.h \
     falloutttwsavegame.h \


### PR DESCRIPTION
The lines added were taken from the FalloutNV save game code.  There
is no reason for the two to be different as TTW is essentially FalloutNV
with specific mods.  TTW save games can now be correctly read.

Also includes a small fix to a build file that's probably unused.