### PR TITLE
Command line and instance dialogs

### DIFF
--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -30,13 +30,18 @@ GameFalloutTTW::GameFalloutTTW()
 {
 }
 
+void GameFalloutTTW::registered()
+{
+  GameGamebryo::registered();
+  m_MyGamesPath = determineMyGamesPath("FalloutNV");
+}
+
 bool GameFalloutTTW::init(IOrganizer *moInfo)
 {
   if (!GameGamebryo::init(moInfo)) {
     return false;
   }
-  m_GamePath = identifyGamePath();
-  m_MyGamesPath = determineMyGamesPath("FalloutNV");
+
   registerFeature<ScriptExtender>(new FalloutTTWScriptExtender(this));
   registerFeature<DataArchives>(new FalloutTTWDataArchives(myGamesPath()));
   registerFeature<BSAInvalidation>(new FalloutTTWBSAInvalidation(feature<DataArchives>(), this));

--- a/src/gamefalloutttw.h
+++ b/src/gamefalloutttw.h
@@ -17,7 +17,8 @@ public:
 
   GameFalloutTTW();
 
-  virtual bool init(MOBase::IOrganizer *moInfo) override;
+  void registered() override;
+  bool init(MOBase::IOrganizer *moInfo) override;
 
 public: // IPluginGame interface
 


### PR DESCRIPTION
Moved path detection to `registered()` so it can happen without `init()` being called. `m_GamePath` is already set by gamebryo.