### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -100,7 +100,7 @@ QString GameFalloutTTW::description() const
 
 MOBase::VersionInfo GameFalloutTTW::version() const
 {
-  return VersionInfo(1, 4, 1, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 5, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameFalloutTTW::settings() const

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -112,7 +112,6 @@ void GameFalloutTTW::initializeProfile(const QDir &path, ProfileSettings setting
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/FalloutNV", path, "plugins.txt");
-    copyToProfile(localAppFolder() + "/FalloutNV", path, "loadorder.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.