### PR TITLE
Fix steam game directory check

### DIFF
--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -73,7 +73,8 @@ QDir GameFalloutTTW::documentsDirectory() const
 
 QString GameFalloutTTW::identifyGamePath() const
 {
-  auto result = GameGamebryo::identifyGamePath();  // Default registry path
+  QString path = "Software\\Bethesda Softworks\\FalloutNV";
+  auto result = findInRegistry(HKEY_LOCAL_MACHINE, path.toStdWString().c_str(), L"Installed Path");
   // EPIC Game Store
   if (result.isEmpty()) {
     /**


### PR DESCRIPTION
The NV changes were ported a little too aggressively. Since TTW doesn't use the short name necessary to look up the registry entry, the default Gamebryo registry check does not work.