### PR TITLE
Revert change for category source

### DIFF
--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -284,7 +284,7 @@ QStringList GameFalloutTTW::validShortNames() const
 
 QString GameFalloutTTW::gameNexusName() const
 {
-  return "newvegas";
+  return "";
 }
 
 QStringList GameFalloutTTW::iniFiles() const
@@ -310,7 +310,7 @@ int GameFalloutTTW::nexusModOrganizerID() const
 
 int GameFalloutTTW::nexusGameID() const
 {
-  return 130;
+  return 0;
 }
 
 QDir GameFalloutTTW::gameDirectory() const


### PR DESCRIPTION
We can instead add a check for the primary game source when determining what game to use for fetching categories.

Still to do (for another version): Implement the ability to map alternate game source categories.