### PR TITLE
KEYWORDS and BaseObjectSwapper valid folders.

### DIFF
--- a/src/falloutttwmoddatachecker.h
+++ b/src/falloutttwmoddatachecker.h
@@ -9,21 +9,24 @@ public:
   using GamebryoModDataChecker::GamebryoModDataChecker;
 
 protected:
-  virtual const FileNameSet& possibleFolderNames() const override {
-    static FileNameSet result{
-      "fonts", "interface", "menus", "meshes", "music", "scripts", "shaders",
-      "sound", "strings", "textures", "trees", "video", "facegen", "materials",
-      "nvse", "distantlod", "asi", "Tools", "MCM", "distantland", "mits",
-      "dllplugins", "CalienteTools", "shadersfx", "config"
-    };
+  virtual const FileNameSet& possibleFolderNames() const override
+  {
+    static FileNameSet result{"fonts",      "interface",     "menus",
+                              "meshes",     "music",         "scripts",
+                              "shaders",    "sound",         "strings",
+                              "textures",   "trees",         "video",
+                              "facegen",    "materials",     "nvse",
+                              "distantlod", "asi",           "Tools",
+                              "MCM",        "distantland",   "mits",
+                              "dllplugins", "CalienteTools", "shadersfx",
+                              "config",     "KEYWORDS",      "BaseObjectSwapper"};
     return result;
   }
-  virtual const FileNameSet& possibleFileExtensions() const override {
-    static FileNameSet result{
-      "esp", "esm", "bsa", "modgroups", "ini"
-    };
+  virtual const FileNameSet& possibleFileExtensions() const override
+  {
+    static FileNameSet result{"esp", "esm", "bsa", "modgroups", "ini"};
     return result;
   }
 };
 
-#endif // FALLOUTTTW_MODATACHECKER_H
+#endif  // FALLOUTTTW_MODATACHECKER_H

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -220,7 +220,6 @@ void GameFalloutTTW::initializeProfile(const QDir& path, ProfileSettings setting
 
     copyToProfile(myGamesPath(), path, "falloutprefs.ini");
     copyToProfile(myGamesPath(), path, "falloutcustom.ini");
-    copyToProfile(myGamesPath(), path, "custom.ini");
     copyToProfile(myGamesPath(), path, "GECKCustom.ini");
     copyToProfile(myGamesPath(), path, "GECKPrefs.ini");
   }
@@ -289,8 +288,8 @@ QString GameFalloutTTW::gameNexusName() const
 
 QStringList GameFalloutTTW::iniFiles() const
 {
-  return {"fallout.ini", "falloutprefs.ini", "falloutcustom.ini",
-          "custom.ini",  "GECKCustom.ini",   "GECKPrefs.ini"};
+  return {"fallout.ini", "falloutprefs.ini", "falloutcustom.ini", "GECKCustom.ini",
+          "GECKPrefs.ini"};
 }
 
 QStringList GameFalloutTTW::DLCPlugins() const


### PR DESCRIPTION
This allows KEYWORDS and BaseObjectSwapper folders to be recognized as valid. I also applied the .clang-format file from the modorganizer-game_falloutnv repository for consistency.