### PR TITLE
Update exec info & plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,1 @@
-https://github.com/ModOrganizer2/modorganizer
-
-https://github.com/Ungeziefi/ML-ModOrganizer2
-
-https://github.com/Ungeziefi/ML-USVFS
-
-https://github.com/Ungeziefi/ML-NXMHandler
-
-https://github.com/Ungeziefi/ML-DiagnoseBasic
-
-https://github.com/Ungeziefi/ML-TTWPlugin
+https://www.nexusmods.com/site/mods/874

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+https://github.com/ModOrganizer2/modorganizer
+
+https://github.com/Ungeziefi/ML-ModOrganizer2
+
+https://github.com/Ungeziefi/ML-USVFS
+
+https://github.com/Ungeziefi/ML-NXMHandler
+
+https://github.com/Ungeziefi/ML-DiagnoseBasic
+
+https://github.com/Ungeziefi/ML-TTWPlugin

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-https://www.nexusmods.com/site/mods/874

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -151,9 +151,7 @@ QList<ExecutableInfo> GameFalloutTTW::executables() const
   ExecutableInfo launcher("Fallout Launcher", findInGameFolder(getLauncherName()));
   QList<ExecutableInfo> extraExecutables =
       QList<ExecutableInfo>()
-      << ExecutableInfo("Fallout Mod Manager", findInGameFolder("fomm/fomm.exe"))
       << ExecutableInfo("Construction Kit", findInGameFolder("geck.exe"))
-      << ExecutableInfo("BOSS", findInGameFolder("BOSS/BOSS.exe"))
       << ExecutableInfo("LOOT", QFileInfo(getLootPath()))
              .withArgument("--game=\"FalloutNV\"");
   if (selectedVariant() != "Epic Games") {

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -253,7 +253,7 @@ QStringList GameFalloutTTW::primaryPlugins() const
           "fallout3.esm",      "anchorage.esm",          "thepitt.esm",
           "brokensteel.esm",   "pointlookout.esm",       "zeta.esm",
           "caravanpack.esm",   "classicpack.esm",        "mercenarypack.esm",
-          "tribalpack.esm",    "taleoftwowastelands.esm"};
+          "tribalpack.esm",    "taleoftwowastelands.esm","YUPTTW.esm"};
 }
 
 QStringList GameFalloutTTW::gameVariants() const

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -151,7 +151,7 @@ QList<ExecutableInfo> GameFalloutTTW::executables() const
   ExecutableInfo launcher("Fallout Launcher", findInGameFolder(getLauncherName()));
   QList<ExecutableInfo> extraExecutables =
       QList<ExecutableInfo>()
-      << ExecutableInfo("Construction Kit", findInGameFolder("geck.exe"))
+      << ExecutableInfo("GECK", findInGameFolder("geck.exe"))
       << ExecutableInfo("LOOT", QFileInfo(getLootPath()))
              .withArgument("--game=\"FalloutNV\"");
   if (selectedVariant() != "Epic Games") {


### PR DESCRIPTION
# Authors
- @Senjay-id
- @Ungeziefi

# Motivations
This plugin is particularly dated in several different spots, so a general update is needed

# Modifications
- Remove FOMM & BOSS, these are extremely dated and no longer maintained or used
- Rename Construction Kit to GECK, which is more well known
- Add `UPTTW.esm` to the primary plugin list, this is shipped with TTW