### PR TITLE
Add plugin setting to enable/disable LOOT & add loot & display name

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,41 @@
+---
+# We'll use defaults from the LLVM style, but with 4 columns indentation.
+BasedOnStyle: LLVM
+IndentWidth: 2
+---
+Language: Cpp
+DeriveLineEnding: false
+UseCRLF: true
+DerivePointerAlignment: false
+PointerAlignment: Left
+AlignConsecutiveAssignments: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Empty
+AlwaysBreakTemplateDeclarations: Yes
+AccessModifierOffset: -2
+AlignTrailingComments: true
+SpacesBeforeTrailingComments: 2
+NamespaceIndentation: Inner
+MaxEmptyLinesToKeep: 1
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: true
+ColumnLimit: 88
+ForEachMacros: ['Q_FOREACH', 'foreach']

--- a/src/game_ttw_en.ts
+++ b/src/game_ttw_en.ts
@@ -4,12 +4,12 @@
 <context>
     <name>GameFalloutTTW</name>
     <message>
-        <location filename="gamefalloutttw.cpp" line="88"/>
+        <location filename="gamefalloutttw.cpp" line="186"/>
         <source>Fallout TTW Support Plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamefalloutttw.cpp" line="98"/>
+        <location filename="gamefalloutttw.cpp" line="196"/>
         <source>Adds support for the game Fallout TTW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -172,6 +172,8 @@
     <message>
         <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="330"/>
         <source>failed to query registry path (read): %1</source>
+        <location filename="gamefalloutttw.cpp" line="208"/>
+        <source>While not recommended by the TTW modding community, enables LOOT sorting</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/game_ttw_en.ts
+++ b/src/game_ttw_en.ts
@@ -4,18 +4,174 @@
 <context>
     <name>GameFalloutTTW</name>
     <message>
-        <location filename="gamefalloutttw.cpp" line="181"/>
+        <location filename="gamefalloutttw.cpp" line="88"/>
         <source>Fallout TTW Support Plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamefalloutttw.cpp" line="191"/>
+        <location filename="gamefalloutttw.cpp" line="98"/>
         <source>Adds support for the game Fallout TTW</source>
         <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>GamebryoModDataContent</name>
     <message>
-        <location filename="gamefalloutttw.cpp" line="203"/>
-        <source>While not recommended by the TTW modding community, enables LOOT sorting</source>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="12"/>
+        <source>Plugins (ESP/ESM/ESL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="13"/>
+        <source>Optional Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="14"/>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="15"/>
+        <source>Meshes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="16"/>
+        <source>Bethesda Archive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="17"/>
+        <source>Scripts (Papyrus)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="18"/>
+        <source>Script Extender Plugin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="19"/>
+        <source>Script Extender Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="20"/>
+        <source>SkyProc Patcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="21"/>
+        <source>Sound or Music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="22"/>
+        <source>Textures</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="23"/>
+        <source>MCM Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="24"/>
+        <source>INI Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="25"/>
+        <source>FaceGen Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="26"/>
+        <source>ModGroup Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GamebryoSaveGameInfoWidget</name>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="39"/>
+        <source>Save #</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="51"/>
+        <source>Character</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="63"/>
+        <source>Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="75"/>
+        <source>Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="87"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="72"/>
+        <source>Has Script Extender Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="77"/>
+        <source>Missing ESPs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="110"/>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="148"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="116"/>
+        <source>Missing ESLs</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../game_gamebryo/src/creation/creationgameplugins.cpp" line="105"/>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryogameplugins.cpp" line="127"/>
+        <source>Some of your plugins have invalid names! These plugins can not be loaded by the game. Please see mo_interface.log for a list of affected plugins and rename them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegame.cpp" line="47"/>
+        <source>%1, #%2, Level %3, %4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegame.cpp" line="97"/>
+        <source>failed to open %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegame.cpp" line="107"/>
+        <source>wrong file format - expected %1 got %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="323"/>
+        <source>failed to query registry path (preflight): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="330"/>
+        <source>failed to query registry path (read): %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/game_ttw_en.ts
+++ b/src/game_ttw_en.ts
@@ -4,174 +4,18 @@
 <context>
     <name>GameFalloutTTW</name>
     <message>
-        <location filename="gamefalloutttw.cpp" line="88"/>
+        <location filename="gamefalloutttw.cpp" line="181"/>
         <source>Fallout TTW Support Plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gamefalloutttw.cpp" line="98"/>
+        <location filename="gamefalloutttw.cpp" line="191"/>
         <source>Adds support for the game Fallout TTW</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>GamebryoModDataContent</name>
     <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="12"/>
-        <source>Plugins (ESP/ESM/ESL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="13"/>
-        <source>Optional Plugins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="14"/>
-        <source>Interface</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="15"/>
-        <source>Meshes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="16"/>
-        <source>Bethesda Archive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="17"/>
-        <source>Scripts (Papyrus)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="18"/>
-        <source>Script Extender Plugin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="19"/>
-        <source>Script Extender Files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="20"/>
-        <source>SkyProc Patcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="21"/>
-        <source>Sound or Music</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="22"/>
-        <source>Textures</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="23"/>
-        <source>MCM Configuration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="24"/>
-        <source>INI Files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="25"/>
-        <source>FaceGen Data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryomoddatacontent.cpp" line="26"/>
-        <source>ModGroup Files</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>GamebryoSaveGameInfoWidget</name>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="39"/>
-        <source>Save #</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="51"/>
-        <source>Character</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="63"/>
-        <source>Level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="75"/>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.ui" line="87"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="72"/>
-        <source>Has Script Extender Data</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="77"/>
-        <source>Missing ESPs</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="110"/>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="148"/>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegameinfowidget.cpp" line="116"/>
-        <source>Missing ESLs</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../../game_gamebryo/src/creation/creationgameplugins.cpp" line="105"/>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryogameplugins.cpp" line="127"/>
-        <source>Some of your plugins have invalid names! These plugins can not be loaded by the game. Please see mo_interface.log for a list of affected plugins and rename them.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegame.cpp" line="47"/>
-        <source>%1, #%2, Level %3, %4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegame.cpp" line="97"/>
-        <source>failed to open %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamebryosavegame.cpp" line="107"/>
-        <source>wrong file format - expected %1 got %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="323"/>
-        <source>failed to query registry path (preflight): %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../game_gamebryo/src/gamebryo/gamegamebryo.cpp" line="330"/>
-        <source>failed to query registry path (read): %1</source>
+        <location filename="gamefalloutttw.cpp" line="203"/>
+        <source>While not recommended by the TTW modding community, enables LOOT sorting</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -132,7 +132,7 @@ QString GameFalloutTTW::gameName() const
 
 QString GameFalloutTTW::displayGameName() const
 {
-    return "Fallout Tale of Two Wastelands";
+    return "Tale of Two Wastelands";
 }
 
 QString GameFalloutTTW::gameDirectoryName() const

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -127,7 +127,12 @@ bool GameFalloutTTW::isInstalled() const
 
 QString GameFalloutTTW::gameName() const
 {
-    return "Tale of Two Wastelands";
+  return "TTW";
+}
+
+QString GameFalloutTTW::displayGameName() const
+{
+    return "Fallout Tale of Two Wastelands";
 }
 
 QString GameFalloutTTW::gameDirectoryName() const
@@ -270,7 +275,7 @@ QString GameFalloutTTW::binaryName() const
 
 QString GameFalloutTTW::gameShortName() const
 {
-    return "FalloutNV";
+  return "TTW";
 }
 
 QStringList GameFalloutTTW::primarySources() const
@@ -301,9 +306,14 @@ QStringList GameFalloutTTW::DLCPlugins() const
 
 MOBase::IPluginGame::SortMechanism GameFalloutTTW::sortMechanism() const
 {
-    if (m_Organizer->pluginSetting(name(), "enable_loot_sorting").toBool())
-        return IPluginGame::SortMechanism::LOOT;
-    return IPluginGame::SortMechanism::NONE;
+   if (m_Organizer->pluginSetting(name(), "enable_loot_sorting").toBool())
+      return IPluginGame::SortMechanism::LOOT;
+   return IPluginGame::SortMechanism::NONE;
+}
+
+QString GameFalloutTTW::lootGameName() const
+{
+    return "FalloutNV";
 }
 
 int GameFalloutTTW::nexusModOrganizerID() const

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -285,7 +285,7 @@ QStringList GameFalloutTTW::validShortNames() const
 
 QString GameFalloutTTW::gameNexusName() const
 {
-    return "newvegas";
+    return "";
 }
 
 QStringList GameFalloutTTW::iniFiles() const

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -127,7 +127,7 @@ bool GameFalloutTTW::isInstalled() const
 
 QString GameFalloutTTW::gameName() const
 {
-  return "TTW";
+    return "Tale of Two Wastelands";
 }
 
 QString GameFalloutTTW::gameDirectoryName() const
@@ -198,7 +198,11 @@ MOBase::VersionInfo GameFalloutTTW::version() const
 
 QList<PluginSetting> GameFalloutTTW::settings() const
 {
-  return QList<PluginSetting>();
+    return QList<PluginSetting>()
+           << PluginSetting("enable_loot_sorting",
+                            tr("While not recommended by the TTW modding community, "
+                               "enables LOOT sorting"),
+                            false);
 }
 
 void GameFalloutTTW::initializeProfile(const QDir& path, ProfileSettings settings) const
@@ -266,7 +270,7 @@ QString GameFalloutTTW::binaryName() const
 
 QString GameFalloutTTW::gameShortName() const
 {
-  return "TTW";
+    return "FalloutNV";
 }
 
 QStringList GameFalloutTTW::primarySources() const
@@ -281,7 +285,7 @@ QStringList GameFalloutTTW::validShortNames() const
 
 QString GameFalloutTTW::gameNexusName() const
 {
-  return "";
+    return "newvegas";
 }
 
 QStringList GameFalloutTTW::iniFiles() const
@@ -297,7 +301,9 @@ QStringList GameFalloutTTW::DLCPlugins() const
 
 MOBase::IPluginGame::SortMechanism GameFalloutTTW::sortMechanism() const
 {
-  return SortMechanism::NONE;
+    if (m_Organizer->pluginSetting(name(), "enable_loot_sorting").toBool())
+        return IPluginGame::SortMechanism::LOOT;
+    return IPluginGame::SortMechanism::NONE;
 }
 
 int GameFalloutTTW::nexusModOrganizerID() const

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -285,7 +285,7 @@ QStringList GameFalloutTTW::validShortNames() const
 
 QString GameFalloutTTW::gameNexusName() const
 {
-    return "";
+  return "";
 }
 
 QStringList GameFalloutTTW::iniFiles() const

--- a/src/gamefalloutttw.cpp
+++ b/src/gamefalloutttw.cpp
@@ -74,7 +74,8 @@ QDir GameFalloutTTW::documentsDirectory() const
 QString GameFalloutTTW::identifyGamePath() const
 {
   QString path = "Software\\Bethesda Softworks\\FalloutNV";
-  auto result = findInRegistry(HKEY_LOCAL_MACHINE, path.toStdWString().c_str(), L"Installed Path");
+  auto result  = findInRegistry(HKEY_LOCAL_MACHINE, path.toStdWString().c_str(),
+                                L"Installed Path");
   // EPIC Game Store
   if (result.isEmpty()) {
     /**
@@ -132,7 +133,7 @@ QString GameFalloutTTW::gameName() const
 
 QString GameFalloutTTW::displayGameName() const
 {
-    return "Tale of Two Wastelands";
+  return "Tale of Two Wastelands";
 }
 
 QString GameFalloutTTW::gameDirectoryName() const
@@ -155,10 +156,9 @@ QList<ExecutableInfo> GameFalloutTTW::executables() const
   ExecutableInfo game("Tale of Two Wastelands", findInGameFolder(binaryName()));
   ExecutableInfo launcher("Fallout Launcher", findInGameFolder(getLauncherName()));
   QList<ExecutableInfo> extraExecutables =
-      QList<ExecutableInfo>()
-      << ExecutableInfo("GECK", findInGameFolder("geck.exe"))
-      << ExecutableInfo("LOOT", QFileInfo(getLootPath()))
-             .withArgument("--game=\"FalloutNV\"");
+      QList<ExecutableInfo>() << ExecutableInfo("GECK", findInGameFolder("geck.exe"))
+                              << ExecutableInfo("LOOT", QFileInfo(getLootPath()))
+                                     .withArgument("--game=\"FalloutNV\"");
   if (selectedVariant() != "Epic Games") {
     extraExecutables.prepend(ExecutableInfo(
         "NVSE", findInGameFolder(feature<ScriptExtender>()->loaderName())));
@@ -203,11 +203,11 @@ MOBase::VersionInfo GameFalloutTTW::version() const
 
 QList<PluginSetting> GameFalloutTTW::settings() const
 {
-    return QList<PluginSetting>()
-           << PluginSetting("enable_loot_sorting",
-                            tr("While not recommended by the TTW modding community, "
-                               "enables LOOT sorting"),
-                            false);
+  return QList<PluginSetting>()
+         << PluginSetting("enable_loot_sorting",
+                          tr("While not recommended by the TTW modding community, "
+                             "enables LOOT sorting"),
+                          false);
 }
 
 void GameFalloutTTW::initializeProfile(const QDir& path, ProfileSettings settings) const
@@ -255,12 +255,12 @@ QString GameFalloutTTW::steamAPPId() const
 
 QStringList GameFalloutTTW::primaryPlugins() const
 {
-  return {"falloutnv.esm",     "deadmoney.esm",          "honesthearts.esm",
-          "oldworldblues.esm", "lonesomeroad.esm",       "gunrunnersarsenal.esm",
-          "fallout3.esm",      "anchorage.esm",          "thepitt.esm",
-          "brokensteel.esm",   "pointlookout.esm",       "zeta.esm",
-          "caravanpack.esm",   "classicpack.esm",        "mercenarypack.esm",
-          "tribalpack.esm",    "taleoftwowastelands.esm","YUPTTW.esm"};
+  return {"falloutnv.esm",     "deadmoney.esm",           "honesthearts.esm",
+          "oldworldblues.esm", "lonesomeroad.esm",        "gunrunnersarsenal.esm",
+          "fallout3.esm",      "anchorage.esm",           "thepitt.esm",
+          "brokensteel.esm",   "pointlookout.esm",        "zeta.esm",
+          "caravanpack.esm",   "classicpack.esm",         "mercenarypack.esm",
+          "tribalpack.esm",    "taleoftwowastelands.esm", "YUPTTW.esm"};
 }
 
 QStringList GameFalloutTTW::gameVariants() const
@@ -306,14 +306,14 @@ QStringList GameFalloutTTW::DLCPlugins() const
 
 MOBase::IPluginGame::SortMechanism GameFalloutTTW::sortMechanism() const
 {
-   if (m_Organizer->pluginSetting(name(), "enable_loot_sorting").toBool())
-      return IPluginGame::SortMechanism::LOOT;
-   return IPluginGame::SortMechanism::NONE;
+  if (m_Organizer->pluginSetting(name(), "enable_loot_sorting").toBool())
+    return IPluginGame::SortMechanism::LOOT;
+  return IPluginGame::SortMechanism::NONE;
 }
 
 QString GameFalloutTTW::lootGameName() const
 {
-    return "FalloutNV";
+  return "FalloutNV";
 }
 
 int GameFalloutTTW::nexusModOrganizerID() const

--- a/src/gamefalloutttw.h
+++ b/src/gamefalloutttw.h
@@ -20,6 +20,7 @@ public:
 
 public:  // IPluginGame interface
   virtual QString gameName() const override;
+  virtual QString displayGameName() const override;
   virtual void detectGame() override;
   virtual QList<MOBase::ExecutableInfo> executables() const override;
   virtual QList<MOBase::ExecutableForcedLoadSetting>
@@ -39,6 +40,7 @@ public:  // IPluginGame interface
   virtual int nexusGameID() const override;
   virtual QStringList primarySources() const override;
   virtual SortMechanism sortMechanism() const override;
+  virtual QString lootGameName() const override;
   virtual QString getLauncherName() const override;
 
   virtual bool isInstalled() const override;


### PR DESCRIPTION
# Motivations
While LOOT has been always disabled for this plugin, the FalloutNV LOOT list has been recieving a lot of recent attention https://github.com/loot/falloutnv/commits/v0.21/, so it'd be nice to start offering the option to enable LOOT sorting

It's worth noting that TTW-related mods are lumped into the FalloutNV LOOT list https://github.com/loot/falloutnv/commit/da3c48e70dcf31d2b41dda590f3e59b66a90b5db

# Modifications
- Add a plugin setting to enable the LOOT sorting button
- Add `displayGameName()` override so that we can purely display a more accurate name for this plugin, "TTW" doesn't really cut it
- Add `lootGameName()` override so that LOOT can successfully be ran for this plugin (TTW is not a valid LOOT game)
- Add `.clang-format`, it was missing